### PR TITLE
Added support for DAC VGA 6 bits RGB

### DIFF
--- a/fpga/common/Top.sv
+++ b/fpga/common/Top.sv
@@ -1,5 +1,5 @@
 // Copyright Jamie Iles, 2017
-// Some modifications by Joseba Epalza <jepalza> and Aitor Gómez García <spark2k06>
+//
 // This file is part of s80x86.
 //
 // s80x86 is free software: you can redistribute it and/or modify
@@ -32,17 +32,10 @@ module Top(input logic clk,
 `ifdef CONFIG_VGA
 	   output logic vga_hsync,
 	   output logic vga_vsync,
-	   output logic [3:0] vga_r,
-	   output logic [3:0] vga_g,
-	   output logic [3:0] vga_b,
+	   output logic [`CONFIG_VGA_DAC_BITS-1:0] vga_r,
+	   output logic [`CONFIG_VGA_DAC_BITS-1:0] vga_g,
+	   output logic [`CONFIG_VGA_DAC_BITS-1:0] vga_b,
 `endif // CONFIG_VGA
-`ifdef CONFIG_VGA666
-	   output logic vga_hsync,
-	   output logic vga_vsync,
-	   output logic [5:0] vga_ro,
-	   output logic [5:0] vga_go,
-	   output logic [5:0] vga_bo,
-`endif // CONFIG_VGA666
 `ifdef CONFIG_PS2
            inout ps2_clk,
            inout ps2_dat,
@@ -62,7 +55,7 @@ wire reset_n;
 wire pll_locked;
 wire reset = ~reset_n | debug_reset | poweron_reset;
 
-`ifdef CONFIG_VGACOMMON
+`ifdef CONFIG_VGA
 wire vga_clk;
 
 wire vga_reg_access;
@@ -72,6 +65,14 @@ wire [15:0] vga_reg_data;
 wire vga_access;
 wire vga_ack;
 wire [15:0] vga_data;
+
+wire [3:0] vga_r4;
+wire [3:0] vga_g4;
+wire [3:0] vga_b4;
+
+assign vga_r = {vga_r4, {`CONFIG_VGA_DAC_BITS-4{1'b0}}};
+assign vga_g = {vga_g4, {`CONFIG_VGA_DAC_BITS-4{1'b0}}};
+assign vga_b = {vga_b4, {`CONFIG_VGA_DAC_BITS-4{1'b0}}};
 `endif
 
 wire [1:0] ir;
@@ -96,9 +97,9 @@ wire [15:0] io_data = sdram_config_data |
     timer_data |
     irq_control_data |
     pic_data |
-`ifdef CONFIG_VGACOMMON
+`ifdef CONFIG_VGA
     vga_reg_data |
-`endif // CONFIG_VGACOMMON
+`endif // CONFIG_VGA
 `ifdef CONFIG_PS2
     ps2_kbd_data |
     ps2_mouse_data |
@@ -126,14 +127,14 @@ wire instr_m_ack;
 wire [19:1] q_m_addr;
 wire [15:0] q_m_data_out;
 wire [15:0] q_m_data_in = sdram_data |
-`ifdef CONFIG_VGACOMMON
+`ifdef CONFIG_VGA
     vga_data |
-`endif // CONFIG_VGACOMMON
+`endif // CONFIG_VGA
     bios_data;
 wire q_m_ack = sdram_ack |
-`ifdef CONFIG_VGACOMMON
+`ifdef CONFIG_VGA
     vga_ack |
-`endif // CONFIG_VGACOMMON
+`endif // CONFIG_VGA
     bios_ack;
 wire q_m_access;
 wire q_m_wr_en;
@@ -218,9 +219,9 @@ wire io_ack = sdram_config_ack |
               irq_control_ack |
               pic_ack |
               timer_ack |
-`ifdef CONFIG_VGACOMMON
+`ifdef CONFIG_VGA
               vga_reg_ack |
-`endif // CONFIG_VGACOMMON
+`endif // CONFIG_VGA
 `ifdef CONFIG_PS2
               ps2_kbd_ack |
               ps2_mouse_ack |
@@ -240,9 +241,9 @@ always_comb begin
     pic_access = 1'b0;
     timer_access = 1'b0;
     bios_control_access = 1'b0;
-`ifdef CONFIG_VGACOMMON
+`ifdef CONFIG_VGA
     vga_reg_access = 1'b0;
-`endif // CONFIG_VGACOMMON
+`endif // CONFIG_VGA
 `ifdef CONFIG_PS2
     ps2_kbd_access = 1'b0;
     ps2_mouse_access = 1'b0;
@@ -258,9 +259,9 @@ always_comb begin
         16'b1111_1111_1110_1100: bios_control_access = 1'b1;
         16'b0000_0000_0100_00z0: timer_access = 1'b1;
         16'b0000_0000_0010_0000: pic_access = 1'b1;
-`ifdef CONFIG_VGACOMMON
+`ifdef CONFIG_VGA
         16'b0000_0011_110z_zzzz: vga_reg_access = 1'b1;
-`endif // CONFIG_VGACOMMON
+`endif // CONFIG_VGA
 `ifdef CONFIG_PS2
         16'b1111_1111_1110_0000: ps2_mouse_access = 1'b1;
         16'b0000_0000_0110_0000: ps2_kbd_access = 1'b1;
@@ -273,17 +274,17 @@ end
 always_comb begin
     sdram_access = 1'b0;
     bios_access = 1'b0;
-`ifdef CONFIG_VGACOMMON
+`ifdef CONFIG_VGA
     vga_access = 1'b0;
-`endif // CONFIG_VGACOMMON
+`endif // CONFIG_VGA
 
     if (q_m_access) begin
         unique casez ({bios_enabled, q_m_addr, 1'b0})
         {1'b1, 20'b1111_11??_????_????_????}: bios_access = 1'b1;
-`ifdef CONFIG_VGACOMMON
+`ifdef CONFIG_VGA
         {1'b?, 20'b1011_10??_????_????_????}: vga_access = 1'b1;
         {1'b?, 20'b1010_????_????_????_????}: vga_access = 1'b1;
-`endif // CONFIG_VGACOMMON
+`endif // CONFIG_VGA
         default: sdram_access = 1'b1;
         endcase
     end
@@ -472,12 +473,7 @@ Timer Timer(.clk(sys_clk),
             .intr(timer_intr),
             .*);
 
-`ifdef CONFIG_VGA666
-wire [3:0] vga_r;
-wire [3:0] vga_g;
-wire [3:0] vga_b;
-`endif
-`ifdef CONFIG_VGACOMMON
+`ifdef CONFIG_VGA
 wire cursor_enabled;
 wire graphics_enabled;
 wire bright_colors;
@@ -564,6 +560,9 @@ MemArbiter CacheVGAArbiter(.clk(sys_clk),
                            .q_b(arb_to_vga));
 
 VGAController VGAController(.clk(vga_clk),
+                            .vga_r(vga_r4),
+                            .vga_g(vga_g4),
+                            .vga_b(vga_b4),
                             .*);
 
 VGARegisters VGARegisters(.clk(sys_clk),
@@ -582,12 +581,6 @@ assign sdram_m_bytesel = cache_sdram_m_bytesel;
 assign sdram_m_access = cache_sdram_m_access;
 assign sdram_m_wr_en = cache_sdram_m_wr_en;
 `endif
-`ifdef CONFIG_VGA666
-assign vga_ro = {vga_r,2'b00};
-assign vga_go = {vga_g,2'b00};
-assign vga_bo = {vga_b,2'b00};
-`endif
-
 
 `ifdef CONFIG_PS2
 PS2KeyboardController #(.clkf(50000000))

--- a/fpga/de0-cv/defines.sv
+++ b/fpga/de0-cv/defines.sv
@@ -16,7 +16,7 @@
 // along with s80x86.  If not, see <http://www.gnu.org/licenses/>.
 
 `define CONFIG_SDRAM_SIZE (64 * 1024 * 1024)
-`define CONFIG_VGACOMMON 1
+`define CONFIG_VGA_DAC_BITS 4
 `define CONFIG_VGA 1
 `define CONFIG_PS2 1
 `define CONFIG_NUM_LEDS 10

--- a/fpga/de0-cv/defines.sv
+++ b/fpga/de0-cv/defines.sv
@@ -16,6 +16,7 @@
 // along with s80x86.  If not, see <http://www.gnu.org/licenses/>.
 
 `define CONFIG_SDRAM_SIZE (64 * 1024 * 1024)
+`define CONFIG_VGACOMMON 1
 `define CONFIG_VGA 1
 `define CONFIG_PS2 1
 `define CONFIG_NUM_LEDS 10

--- a/fpga/hdp001/defines.sv
+++ b/fpga/hdp001/defines.sv
@@ -16,6 +16,7 @@
 // along with s80x86.  If not, see <http://www.gnu.org/licenses/>.
 
 `define CONFIG_SDRAM_SIZE (32 * 1024 * 1024)
+`define CONFIG_VGACOMMON 1
 `define CONFIG_VGA 1
 `define CONFIG_PS2 1
 `define CONFIG_NUM_LEDS 8

--- a/fpga/hdp001/defines.sv
+++ b/fpga/hdp001/defines.sv
@@ -16,7 +16,7 @@
 // along with s80x86.  If not, see <http://www.gnu.org/licenses/>.
 
 `define CONFIG_SDRAM_SIZE (32 * 1024 * 1024)
-`define CONFIG_VGACOMMON 1
+`define CONFIG_VGA_DAC_BITS 4
 `define CONFIG_VGA 1
 `define CONFIG_PS2 1
 `define CONFIG_NUM_LEDS 8


### PR DESCRIPTION
Added support for DAC VGA 6 bits RGB through define "CONFIG_VGA666" instead of "CONFIG_VGA" for 4 bits. With VGA config defined, now it is necessary to add the define "CONFIG_VGACOMMON" on defines.sv.