### PR TITLE
Lock textX versioning

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -51,7 +51,7 @@ RUN gem install --no-ri --pre \
 RUN mkdir -p /build
 WORKDIR /build
 RUN apt-get install -y python3-setuptools
-RUN pip3 install textX
+RUN pip3 install textX==1.6.1
 RUN rm /usr/bin/gcov; ln -s /usr/bin/llvm-cov /usr/bin/gcov
 RUN cd /tmp && \
         wget $MIRROR$TOOLCHAIN && \


### PR DESCRIPTION
TextX introduced a breaking change in 1.7 a few months ago. This just locks it to keep the build working and sane.