### PR TITLE
Use dummy escape function for generation scripts

### DIFF
--- a/scripts/gen-instructions
+++ b/scripts/gen-instructions
@@ -29,6 +29,7 @@ HERE = os.path.dirname(__file__)
 INSTR_TEMPLATE = os.path.join(HERE, '..', 'documentation', 'instructions.templ')
 
 pystache.defaults.DELIMITERS = (u'<%', u'%>')
+pystache.defaults.TAG_ESCAPE = lambda u: u
 
 with open(os.path.join(HERE, '..', 'documentation', 'instructions.yaml')) as instr:
     instructions = yaml.load(instr)

--- a/scripts/gen-instructions-functions
+++ b/scripts/gen-instructions-functions
@@ -27,6 +27,7 @@ HERE = os.path.dirname(__file__)
 TEMPLATE = os.path.join(HERE, '..', 'rtl', 'InstructionDefinitions.sv.templ')
 
 pystache.defaults.DELIMITERS = (u'<%', u'%>')
+pystache.defaults.TAG_ESCAPE = lambda u: u
 
 with open(os.path.join(HERE, '..', 'documentation', 'instructions.yaml')) as instr:
     instructions = yaml.load(instr)


### PR DESCRIPTION
Fixes an issue introduced by newer versions of pystache that caused it to spit out safe versions of certain characters.

Before
![screenshot from 2018-11-04 03-10-58](https://user-images.githubusercontent.com/8016121/47962241-819c3800-dfdf-11e8-81f9-04faa2e2e2cf.png)

After
![screenshot from 2018-11-04 03-12-12](https://user-images.githubusercontent.com/8016121/47962242-8365fb80-dfdf-11e8-82b6-204e155e1e87.png)
