### PR TITLE
Some tweaks to the BIOS for efficiency and correctness

### DIFF
--- a/bios/bios.h
+++ b/bios/bios.h
@@ -40,6 +40,7 @@ struct callregs {
     union reg cx;
     union reg ax;
     unsigned short ds;
+    unsigned short es;
     unsigned short flags;
 };
 

--- a/bios/disk.c
+++ b/bios/disk.c
@@ -60,7 +60,7 @@ static void disk_read(struct callregs *regs)
     regs->flags &= ~CF;
 
     for (i = 0; i < count; ++i) {
-        read_sector(lba, get_es(), dst);
+        read_sector(lba, regs->es, dst);
         ++lba;
         dst += SECTOR_SIZE;
         ++regs->ax.l;
@@ -90,7 +90,7 @@ static void disk_write(struct callregs *regs)
     regs->flags &= ~CF;
 
     for (i = 0; i < count; ++i) {
-        if (write_sector(lba, get_es(), dst)) {
+        if (write_sector(lba, regs->es, dst)) {
             regs->flags |= CF;
             break;
         }

--- a/bios/display.c
+++ b/bios/display.c
@@ -414,7 +414,7 @@ static void set_dac_block(struct callregs *regs)
     unsigned short idx = regs->bx.x;
     unsigned short count = regs->cx.x;
     unsigned short src = regs->dx.x;
-    unsigned short es = get_es();
+    unsigned short es = regs->es;
 
     outb(0x3c8, idx);
     for (unsigned short m = 0; m < count; ++m)

--- a/bios/entry.S
+++ b/bios/entry.S
@@ -95,6 +95,7 @@ saved_sw_sp: .word 0
 
     // Save registers, setup stack frame
     sub $2, %sp
+    push %es
     push %ds
     pusha
     mov %sp, %bp
@@ -105,7 +106,7 @@ saved_sw_sp: .word 0
     mov %cs:\saved_sp_var, %bx
     mov 0(%bx), %ax
     mov 6(%bx), %bx
-    mov %bx, 18(%bp)
+    mov %bx, 20(%bp)
 
     // Use SS as DS inside the BIOS for stack-local variables that are passed
     // by address
@@ -118,7 +119,7 @@ saved_sw_sp: .word 0
     mov %sp, %bp
 
     // Write possibly updated flags to the iret frame
-    mov 18(%bp), %ax
+    mov 20(%bp), %ax
     mov %cs:\saved_ss_var, %ds
     mov %cs:\saved_sp_var, %bx
     mov %ax, 6(%bx)
@@ -127,6 +128,7 @@ saved_sw_sp: .word 0
     // already
     popa
     pop %ds
+    pop %es
     add $2, %sp
 
     // Restore the callers stack

--- a/bios/io.h
+++ b/bios/io.h
@@ -180,17 +180,3 @@ static inline unsigned short get_cs(void)
 
     return cs;
 }
-
-static inline unsigned short get_es(void)
-{
-    unsigned short es;
-
-    asm volatile("mov %%es, %0" : "=r"(es));
-
-    return es;
-}
-
-static inline void set_es(unsigned short es)
-{
-    asm volatile("mov %0, %%es" ::"r"(es));
-}

--- a/bios/io.h
+++ b/bios/io.h
@@ -25,11 +25,9 @@ static inline void outw(unsigned short port, unsigned short v)
 static inline void outb(unsigned short port, unsigned char v)
 {
     asm volatile(
-        "mov %0, %%al\n"
-        "outb %%al, %w1"
+        "outb %0, %w1"
         :
-        : "a"(v), "Nd"(port)
-        : "%al");
+        : "Ral"(v), "Nd"(port));
 }
 
 static inline unsigned short inw(unsigned short port)
@@ -46,11 +44,9 @@ static inline unsigned char inb(unsigned short port)
     unsigned char v;
 
     asm volatile(
-        "inb %w1, %%al\n"
-        "mov %%al, %0"
-        : "=a"(v)
-        : "Nd"(port)
-        : "%al");
+        "inb %w1, %0\n"
+        : "=Ral"(v)
+        : "Nd"(port));
 
     return v;
 }

--- a/bios/io.h
+++ b/bios/io.h
@@ -51,6 +51,7 @@ static inline unsigned char inb(unsigned short port)
     return v;
 }
 
+#ifndef __FAR
 static inline void writeb(unsigned short segment,
                           unsigned short address,
                           unsigned char val)
@@ -80,6 +81,25 @@ static inline void writew(unsigned short segment,
         : [segment] "r"(segment), [address] "m"(address), [val] "r"(val)
         : "%bx", "memory");
 }
+#else
+static inline void writeb(unsigned short segment,
+                          unsigned short address,
+                          unsigned char val)
+{
+    unsigned char volatile __far *fp = (unsigned char volatile __far *)
+        ((unsigned long)segment << 16 | address);
+    *fp = val;
+}
+
+static inline void writew(unsigned short segment,
+                          unsigned short address,
+                          unsigned short val)
+{
+    unsigned short volatile __far *fp = (unsigned short volatile __far *)
+        ((unsigned long)segment << 16 | address);
+    *fp = val;
+}
+#endif
 
 static inline void memcpy_seg(unsigned short dseg,
                               void *dst,
@@ -132,6 +152,7 @@ static inline void memset_seg(unsigned short dseg,
         : "memory", "cc");
 }
 
+#ifndef __FAR
 static inline unsigned char readb(unsigned short segment,
                                   unsigned short address)
 {
@@ -167,6 +188,23 @@ static inline unsigned short readw(unsigned short segment,
 
     return v;
 }
+#else
+static inline unsigned char readb(unsigned short segment,
+                                  unsigned short address)
+{
+    unsigned char volatile __far *fp = (unsigned char volatile __far *)
+        ((unsigned long)segment << 16 | address);
+    return *fp;
+}
+
+static inline unsigned short readw(unsigned short segment,
+                                   unsigned short address)
+{
+    unsigned short volatile __far *fp = (unsigned short volatile __far *)
+        ((unsigned long)segment << 16 | address);
+    return *fp;
+}
+#endif
 
 static inline unsigned short get_cs(void)
 {


### PR DESCRIPTION
Hello @jamieiles ,

I would like to propose some tweaks to the BIOS implementation to
  * change the way that interrupt service routines get `%es` from their callers (since GCC may produce code that temporarily alters `%es`); and
  * streamline the workings of the port I/O and memory read/write routines in `io.h`.

I have not tested the code, since I have yet to to set up the infrastructure to really run the BIOS; but the changes are simple enough, so hopefully they are correct.

Thank you!